### PR TITLE
Include Rake tasks when bundled into an application

### DIFF
--- a/lib/localized_country_select.rb
+++ b/lib/localized_country_select.rb
@@ -1,3 +1,6 @@
+require 'rake'
+load 'tasks/localized_country_select_tasks.rake'
+
 # = LocalizedCountrySelect
 # 
 # View helper for displaying select list with countries:

--- a/lib/tasks/localized_country_select_tasks.rake
+++ b/lib/tasks/localized_country_select_tasks.rake
@@ -63,7 +63,8 @@ namespace :import do
 
 
     # ----- Prepare the output format     ------------------------------------------
-    output =<<HEAD
+    output = "#encoding: UTF-8\n"
+    output <<<<HEAD
 { :#{locale} => {
 
     :countries => {

--- a/lib/tasks/localized_country_select_tasks.rake
+++ b/lib/tasks/localized_country_select_tasks.rake
@@ -52,7 +52,7 @@ namespace :import do
     doc.search("//tr").each do |row|
       if row.search("td[@class='n']") && 
          row.search("td[@class='n']").inner_html =~ /^namesterritory$/ && 
-         row.search("td[@class='g']").inner_html =~ /^[A-Z]{2}/
+         row.search("td[@class='g']").inner_html =~ /^[A-Z]{2}$/
         code   = row.search("td[@class='g']").inner_text
         code   = code[-code.size, 2]
         name   = row.search("td[@class='v']").inner_text

--- a/lib/tasks/localized_country_select_tasks.rake
+++ b/lib/tasks/localized_country_select_tasks.rake
@@ -81,10 +81,10 @@ TAIL
     
     # ----- Write the parsed values into file      ---------------------------------
     puts "\n... writing the output"
-    filename = File.join(File.dirname(__FILE__), '..', '..', 'locale', "#{locale}.rb")
+    filename = File.join(Rails.root, 'config', 'locales', "localized_country_select.#{locale}.rb")
     filename += '.NEW' if File.exists?(filename) # Append 'NEW' if file exists
     File.open(filename, 'w+') { |f| f << output }
-    puts "\n---\nWritten values for the '#{locale}' into file: #{filename}\n"
+    puts "\n---\nWritten values for the locale '#{locale}' into file: #{filename}\n"
     # ------------------------------------------------------------------------------
   end
 


### PR DESCRIPTION
Hey guys, I needed to load this gem into a Rails 3.1.3 application and the rake tasks were not working.  I made a small commit, feel free to integrate into your own gem if you wish.  

This allows `rake -T | grep import` to show the localized_country_select rake tasks when bundled into an application.  
