### PR TITLE
added html_safe to country_options

### DIFF
--- a/lib/localized_country_select.rb
+++ b/lib/localized_country_select.rb
@@ -75,7 +75,7 @@ module ActionView
       # as +selected+ to have it marked as the selected option tag.
       # Country codes listed as an array of symbols in +priority_countries+ argument will be listed first
       def country_options_for_select(selected = nil, priority_countries = nil,options={})
-        country_options = ""
+        country_options = "".html_safe
         if priority_countries
           country_options += options_for_select(LocalizedCountrySelect::priority_countries_array(priority_countries,options), selected)
           country_options += "<option value=\"\" disabled=\"disabled\">-------------</option>\n"


### PR DESCRIPTION
This commit is needed to avoid having the tags string concatenated. I needed this fix in rails 3.2.9.